### PR TITLE
(1) R8G8 texture format, (2) Backend multithreaded information for D3D, (3) Deferred context for setting material/mesh data

### DIFF
--- a/sk_gpu.h
+++ b/sk_gpu.h
@@ -1148,6 +1148,9 @@ void skg_buffer_set_contents(skg_buffer_t *buffer, const void *data, uint32_t si
 	}
 	if (FAILED(hr)) {
 		skg_logf(skg_log_critical, "Failed to set contents of buffer, may not be using a writeable buffer type: 0x%08X", hr);
+		if (!on_main) {
+			ReleaseMutex(d3d_deferred_mtx);
+		}
 		return;
 	}
 
@@ -2278,6 +2281,9 @@ void skg_tex_set_contents_arr(skg_tex_t *tex, const void **data_frames, int32_t 
 		}
 		if (FAILED(hr)) {
 			skg_logf(skg_log_critical, "Failed mapping a texture: 0x%08X", hr);
+			if (!on_main) {
+				ReleaseMutex(d3d_deferred_mtx);
+			}
 			return;
 		}
 

--- a/sk_gpu.h
+++ b/sk_gpu.h
@@ -140,6 +140,7 @@ typedef enum skg_tex_fmt_ {
 	skg_tex_fmt_depthstencil,
 	skg_tex_fmt_depth32,
 	skg_tex_fmt_depth16,
+	skg_tex_fmt_r8g8,
 } skg_tex_fmt_;
 
 typedef enum skg_fmt_ {
@@ -373,6 +374,9 @@ typedef struct skg_swapchain_t {
 
 typedef struct skg_platform_data_t {
 	void *_d3d11_device;
+	void *_d3d11_deferred_context;
+	void *_d3d_deferred_mtx;
+	uint32_t _d3d_main_thread_id;
 } skg_platform_data_t;
 
 #elif defined(SKG_DIRECT3D12)
@@ -937,7 +941,9 @@ void skg_draw_begin() {
 skg_platform_data_t skg_get_platform_data() {
 	skg_platform_data_t result = {};
 	result._d3d11_device = d3d_device;
-
+	result._d3d11_deferred_context = d3d_deferred;
+	result._d3d_deferred_mtx = d3d_deferred_mtx;
+	result._d3d_main_thread_id = d3d_main_thread;
 	return result;
 }
 
@@ -1126,13 +1132,32 @@ void skg_buffer_set_contents(skg_buffer_t *buffer, const void *data, uint32_t si
 		return;
 	}
 
-	D3D11_MAPPED_SUBRESOURCE resource;
-	HRESULT hr = d3d_context->Map(buffer->_buffer, 0, D3D11_MAP_WRITE_DISCARD, 0, &resource);
-	if (SUCCEEDED(hr)) {
-		memcpy(resource.pData, data, size_bytes);
+	HRESULT hr = E_FAIL;
+	D3D11_MAPPED_SUBRESOURCE resource = {};
+
+	// Map the memory so we can access it on CPU! In a multi-threaded
+	// context this can be tricky, here we're using a deferred context to
+	// push this operation over to the main thread. The deferred context is
+	// then executed in skg_draw_begin.
+	bool on_main = GetCurrentThreadId() == d3d_main_thread;
+	if (on_main) {
+		hr = d3d_context->Map(buffer->_buffer, 0, D3D11_MAP_WRITE_DISCARD, 0, &resource);
+	} else {
+		WaitForSingleObject(d3d_deferred_mtx, INFINITE);
+		hr = d3d_deferred->Map(buffer->_buffer, 0, D3D11_MAP_WRITE_DISCARD, 0, &resource);
+	}
+	if (FAILED(hr)) {
+		skg_logf(skg_log_critical, "Failed to set contents of buffer, may not be using a writeable buffer type: 0x%08X", hr);
+		return;
+	}
+
+	memcpy(resource.pData, data, size_bytes);
+		
+	if (on_main) {
 		d3d_context->Unmap(buffer->_buffer, 0);
 	} else {
-		skg_logf(skg_log_critical, "Failed to set contents of buffer, may not be using a writeable buffer type: 0x%08X", hr);
+		d3d_deferred->Unmap(buffer->_buffer, 0);
+		ReleaseMutex(d3d_deferred_mtx);
 	}
 }
 
@@ -1976,6 +2001,7 @@ bool skg_can_make_mips(skg_tex_fmt_ format) {
 	case skg_tex_fmt_r32:
 	case skg_tex_fmt_depth16:
 	case skg_tex_fmt_r16:
+	case skg_tex_fmt_r8g8:
 	case skg_tex_fmt_r8: return true;
 	default: return false;
 	}
@@ -2012,6 +2038,7 @@ void skg_make_mips(D3D11_SUBRESOURCE_DATA *tex_mem, const void *curr_data, skg_t
 			break;
 		case skg_tex_fmt_depth16:
 		case skg_tex_fmt_r16:
+		case skg_tex_fmt_r8g8:
 			skg_downsample_1((uint16_t *)mip_data, mip_w, mip_h, (uint16_t **)&tex_mem[m].pSysMem, &mip_w, &mip_h); 
 			break;
 		case skg_tex_fmt_r8:
@@ -2530,6 +2557,7 @@ int64_t skg_tex_fmt_to_native(skg_tex_fmt_ format){
 	case skg_tex_fmt_r8:            return DXGI_FORMAT_R8_UNORM;
 	case skg_tex_fmt_r16:           return DXGI_FORMAT_R16_UNORM;
 	case skg_tex_fmt_r32:           return DXGI_FORMAT_R32_FLOAT;
+	case skg_tex_fmt_r8g8:          return DXGI_FORMAT_R8G8_UNORM;
 	default: return DXGI_FORMAT_UNKNOWN;
 	}
 }
@@ -2554,6 +2582,7 @@ skg_tex_fmt_ skg_tex_fmt_from_native(int64_t format) {
 	case DXGI_FORMAT_R8_UNORM:            return skg_tex_fmt_r8;
 	case DXGI_FORMAT_R16_UNORM:           return skg_tex_fmt_r16;
 	case DXGI_FORMAT_R32_FLOAT:           return skg_tex_fmt_r32;
+	case DXGI_FORMAT_R8G8_UNORM:          return skg_tex_fmt_r8g8;
 	default: return skg_tex_fmt_none;
 	}
 }
@@ -4612,6 +4641,7 @@ int64_t skg_tex_fmt_to_native(skg_tex_fmt_ format) {
 	case skg_tex_fmt_r8:            return GL_R8;
 	case skg_tex_fmt_r16:           return GL_R16F;
 	case skg_tex_fmt_r32:           return GL_R32F;
+	case skg_tex_fmt_r8g8:          return GL_RG8;
 	default: return 0;
 	}
 }
@@ -4634,6 +4664,7 @@ skg_tex_fmt_ skg_tex_fmt_from_native(int64_t format) {
 	case GL_R8:                 return skg_tex_fmt_r8;
 	case GL_R16UI:              return skg_tex_fmt_r16;
 	case GL_R32F:               return skg_tex_fmt_r32;
+	case GL_RG8:                return skg_tex_fmt_r8g8;
 	default: return skg_tex_fmt_none;
 	}
 }
@@ -4663,6 +4694,7 @@ uint32_t skg_tex_fmt_to_gl_layout(skg_tex_fmt_ format) {
 	case skg_tex_fmt_r8:
 	case skg_tex_fmt_r16:
 	case skg_tex_fmt_r32:           return GL_RED;
+	case skg_tex_fmt_r8g8:          return GL_RG;
 	default: return 0;
 	}
 }
@@ -4687,6 +4719,7 @@ uint32_t skg_tex_fmt_to_gl_type(skg_tex_fmt_ format) {
 	case skg_tex_fmt_r8:            return GL_UNSIGNED_BYTE;
 	case skg_tex_fmt_r16:           return GL_UNSIGNED_SHORT;
 	case skg_tex_fmt_r32:           return GL_FLOAT;
+	case skg_tex_fmt_r8g8:          return GL_UNSIGNED_SHORT;
 	default: return 0;
 	}
 }
@@ -5518,6 +5551,7 @@ uint32_t skg_tex_fmt_size(skg_tex_fmt_ format) {
 	case skg_tex_fmt_r8:            return sizeof(uint8_t );
 	case skg_tex_fmt_r16:           return sizeof(uint16_t);
 	case skg_tex_fmt_r32:           return sizeof(uint32_t);
+	case skg_tex_fmt_r8g8:          return sizeof(uint16_t);
 	default: return 0;
 	}
 }

--- a/src/sk_gpu_common.cpp
+++ b/src/sk_gpu_common.cpp
@@ -797,6 +797,7 @@ uint32_t skg_tex_fmt_size(skg_tex_fmt_ format) {
 	case skg_tex_fmt_r8:            return sizeof(uint8_t );
 	case skg_tex_fmt_r16:           return sizeof(uint16_t);
 	case skg_tex_fmt_r32:           return sizeof(uint32_t);
+	case skg_tex_fmt_r8g8:          return sizeof(uint16_t);
 	default: return 0;
 	}
 }

--- a/src/sk_gpu_dev.h
+++ b/src/sk_gpu_dev.h
@@ -140,6 +140,7 @@ typedef enum skg_tex_fmt_ {
 	skg_tex_fmt_depthstencil,
 	skg_tex_fmt_depth32,
 	skg_tex_fmt_depth16,
+	skg_tex_fmt_r8g8,
 } skg_tex_fmt_;
 
 typedef enum skg_fmt_ {

--- a/src/sk_gpu_dx11.cpp
+++ b/src/sk_gpu_dx11.cpp
@@ -433,6 +433,9 @@ void skg_buffer_set_contents(skg_buffer_t *buffer, const void *data, uint32_t si
 	}
 	if (FAILED(hr)) {
 		skg_logf(skg_log_critical, "Failed to set contents of buffer, may not be using a writeable buffer type: 0x%08X", hr);
+		if (!on_main) {
+			ReleaseMutex(d3d_deferred_mtx);
+		}
 		return;
 	}
 
@@ -1563,6 +1566,9 @@ void skg_tex_set_contents_arr(skg_tex_t *tex, const void **data_frames, int32_t 
 		}
 		if (FAILED(hr)) {
 			skg_logf(skg_log_critical, "Failed mapping a texture: 0x%08X", hr);
+			if (!on_main) {
+				ReleaseMutex(d3d_deferred_mtx);
+			}
 			return;
 		}
 

--- a/src/sk_gpu_dx11.cpp
+++ b/src/sk_gpu_dx11.cpp
@@ -226,7 +226,9 @@ void skg_draw_begin() {
 skg_platform_data_t skg_get_platform_data() {
 	skg_platform_data_t result = {};
 	result._d3d11_device = d3d_device;
-
+	result._d3d11_deferred_context = d3d_deferred;
+	result._d3d_deferred_mtx = d3d_deferred_mtx;
+	result._d3d_main_thread_id = d3d_main_thread;
 	return result;
 }
 
@@ -415,13 +417,32 @@ void skg_buffer_set_contents(skg_buffer_t *buffer, const void *data, uint32_t si
 		return;
 	}
 
-	D3D11_MAPPED_SUBRESOURCE resource;
-	HRESULT hr = d3d_context->Map(buffer->_buffer, 0, D3D11_MAP_WRITE_DISCARD, 0, &resource);
-	if (SUCCEEDED(hr)) {
-		memcpy(resource.pData, data, size_bytes);
+	HRESULT hr = E_FAIL;
+	D3D11_MAPPED_SUBRESOURCE resource = {};
+
+	// Map the memory so we can access it on CPU! In a multi-threaded
+	// context this can be tricky, here we're using a deferred context to
+	// push this operation over to the main thread. The deferred context is
+	// then executed in skg_draw_begin.
+	bool on_main = GetCurrentThreadId() == d3d_main_thread;
+	if (on_main) {
+		hr = d3d_context->Map(buffer->_buffer, 0, D3D11_MAP_WRITE_DISCARD, 0, &resource);
+	} else {
+		WaitForSingleObject(d3d_deferred_mtx, INFINITE);
+		hr = d3d_deferred->Map(buffer->_buffer, 0, D3D11_MAP_WRITE_DISCARD, 0, &resource);
+	}
+	if (FAILED(hr)) {
+		skg_logf(skg_log_critical, "Failed to set contents of buffer, may not be using a writeable buffer type: 0x%08X", hr);
+		return;
+	}
+
+	memcpy(resource.pData, data, size_bytes);
+		
+	if (on_main) {
 		d3d_context->Unmap(buffer->_buffer, 0);
 	} else {
-		skg_logf(skg_log_critical, "Failed to set contents of buffer, may not be using a writeable buffer type: 0x%08X", hr);
+		d3d_deferred->Unmap(buffer->_buffer, 0);
+		ReleaseMutex(d3d_deferred_mtx);
 	}
 }
 
@@ -1265,6 +1286,7 @@ bool skg_can_make_mips(skg_tex_fmt_ format) {
 	case skg_tex_fmt_r32:
 	case skg_tex_fmt_depth16:
 	case skg_tex_fmt_r16:
+	case skg_tex_fmt_r8g8:
 	case skg_tex_fmt_r8: return true;
 	default: return false;
 	}
@@ -1301,6 +1323,7 @@ void skg_make_mips(D3D11_SUBRESOURCE_DATA *tex_mem, const void *curr_data, skg_t
 			break;
 		case skg_tex_fmt_depth16:
 		case skg_tex_fmt_r16:
+		case skg_tex_fmt_r8g8:
 			skg_downsample_1((uint16_t *)mip_data, mip_w, mip_h, (uint16_t **)&tex_mem[m].pSysMem, &mip_w, &mip_h); 
 			break;
 		case skg_tex_fmt_r8:
@@ -1819,6 +1842,7 @@ int64_t skg_tex_fmt_to_native(skg_tex_fmt_ format){
 	case skg_tex_fmt_r8:            return DXGI_FORMAT_R8_UNORM;
 	case skg_tex_fmt_r16:           return DXGI_FORMAT_R16_UNORM;
 	case skg_tex_fmt_r32:           return DXGI_FORMAT_R32_FLOAT;
+	case skg_tex_fmt_r8g8:          return DXGI_FORMAT_R8G8_UNORM;
 	default: return DXGI_FORMAT_UNKNOWN;
 	}
 }
@@ -1843,6 +1867,7 @@ skg_tex_fmt_ skg_tex_fmt_from_native(int64_t format) {
 	case DXGI_FORMAT_R8_UNORM:            return skg_tex_fmt_r8;
 	case DXGI_FORMAT_R16_UNORM:           return skg_tex_fmt_r16;
 	case DXGI_FORMAT_R32_FLOAT:           return skg_tex_fmt_r32;
+	case DXGI_FORMAT_R8G8_UNORM:          return skg_tex_fmt_r8g8;
 	default: return skg_tex_fmt_none;
 	}
 }

--- a/src/sk_gpu_dx11.h
+++ b/src/sk_gpu_dx11.h
@@ -87,4 +87,7 @@ typedef struct skg_swapchain_t {
 
 typedef struct skg_platform_data_t {
 	void *_d3d11_device;
+	void *_d3d11_deferred_context;
+	void *_d3d_deferred_mtx;
+	uint32_t _d3d_main_thread_id;
 } skg_platform_data_t;

--- a/src/sk_gpu_gl.cpp
+++ b/src/sk_gpu_gl.cpp
@@ -2037,6 +2037,7 @@ int64_t skg_tex_fmt_to_native(skg_tex_fmt_ format) {
 	case skg_tex_fmt_r8:            return GL_R8;
 	case skg_tex_fmt_r16:           return GL_R16F;
 	case skg_tex_fmt_r32:           return GL_R32F;
+	case skg_tex_fmt_r8g8:          return GL_RG8;
 	default: return 0;
 	}
 }
@@ -2059,6 +2060,7 @@ skg_tex_fmt_ skg_tex_fmt_from_native(int64_t format) {
 	case GL_R8:                 return skg_tex_fmt_r8;
 	case GL_R16UI:              return skg_tex_fmt_r16;
 	case GL_R32F:               return skg_tex_fmt_r32;
+	case GL_RG8:                return skg_tex_fmt_r8g8;
 	default: return skg_tex_fmt_none;
 	}
 }
@@ -2088,6 +2090,7 @@ uint32_t skg_tex_fmt_to_gl_layout(skg_tex_fmt_ format) {
 	case skg_tex_fmt_r8:
 	case skg_tex_fmt_r16:
 	case skg_tex_fmt_r32:           return GL_RED;
+	case skg_tex_fmt_r8g8:          return GL_RG;
 	default: return 0;
 	}
 }
@@ -2112,6 +2115,7 @@ uint32_t skg_tex_fmt_to_gl_type(skg_tex_fmt_ format) {
 	case skg_tex_fmt_r8:            return GL_UNSIGNED_BYTE;
 	case skg_tex_fmt_r16:           return GL_UNSIGNED_SHORT;
 	case skg_tex_fmt_r32:           return GL_FLOAT;
+	case skg_tex_fmt_r8g8:          return GL_UNSIGNED_SHORT;
 	default: return 0;
 	}
 }


### PR DESCRIPTION
Hey Nick, in order to get support for NV-12 from #21, there were a couple requirements from sk_gpu on my end. I also noticed a potential bug in multithreaded scenarios for setting contents.

### R8G8 texture format for D3D and OpenGL
I haven't worked with GL yet but I'm pretty sure these are right, fact check me if not!
This would include a `tex_format_r8g8 = 17` `TexFormat` in StereoKit.

### Backend multithreaded information
While it is true you can create new deferred contexts rather than use StereoKit's here, it would be very helpful to have access to this information so that I can `Map` my own data in one go (e.g., map multiple textures at a time from a separate thread, like chrominance and luminance). This way you wouldn't have to be limited to mapping on SK's main thread.

In StereoKit in backend.cpp, I added the following:
```
void* backend_d3d11_get_d3d_deferred_mtx() {
#if !defined(SKG_DIRECT3D11)
	log_err(backend_err_wrong_backend);
	return nullptr;
#else
	void* d3d_deferred_mtx;
	skg_platform_data_t platform = skg_get_platform_data();
	d3d_deferred_mtx = platform._d3d_deferred_mtx;
	return d3d_deferred_mtx;
#endif
}
```
Do you think it's okay to keep everything in the same struct for consistency?

### Potential fix for setting a buffer's contents in a MT scenario
I actually had remembered this old issue https://github.com/StereoKit/StereoKit/issues/455 and realized that the deferred context hadn't been applied for here as well. It's not that it solves the issue, just makes it safer code :)

Very cool `skg_flatscreen` demo btw. It only gave me a *little* motion sickness 😄

P.S. I think the header file in the develop branch is a bit different from this header. Seems to be missing some `SKG_LINUX_EGL` additions.

Update: An example use case to see if you're on SK's main thread from external code
```
ID3D11DeviceContext* pCurrentContext = (ID3D11DeviceContext*)backend_d3d11_get_d3d_context();
bool on_main = pCurrentContext->GetType() == D3D11_DEVICE_CONTEXT_IMMEDIATE;
```