### PR TITLE
Fix skshader_editor build

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -20,7 +20,7 @@ add_executable(sk_gpu_test
   src/main.cpp )
 
 skshaderc_compile_headers(sk_gpu_test
-  ${CMAKE_BINARY_DIR}/shaders
+  ${CMAKE_BINARY_DIR}/shaders/
   "-O3 -t xge"
   src/test.hlsl
   src/test2.hlsl )

--- a/skshader_editor/CMakeLists.txt
+++ b/skshader_editor/CMakeLists.txt
@@ -76,9 +76,9 @@ add_executable(skshader_editor
     TextEditor.cpp)
 
 add_custom_command(TARGET skshader_editor POST_BUILD
-    COMMAND ${CMAKE_COMMAND} -E copy_if_different ${CMAKE_CURRENT_SOURCE_DIR}/CascadiaMono.ttf ${CMAKE_BINARY_DIR}/${CMAKE_BUILD_TYPE}/CascadiaMono.ttf
+    COMMAND ${CMAKE_COMMAND} -E copy_if_different ${CMAKE_CURRENT_SOURCE_DIR}/CascadiaMono.ttf ${CMAKE_BINARY_DIR}/$<CONFIG>/CascadiaMono.ttf
     COMMAND ${CMAKE_COMMAND} -E copy_if_different ${CMAKE_CURRENT_SOURCE_DIR}/CascadiaMono.ttf ${CMAKE_BINARY_DIR}/${PROJECT_NAME}/CascadiaMono.ttf
-    COMMAND ${CMAKE_COMMAND} -E copy_if_different ${CMAKE_CURRENT_SOURCE_DIR}/test.png ${CMAKE_BINARY_DIR}/${CMAKE_BUILD_TYPE}/test.png
+    COMMAND ${CMAKE_COMMAND} -E copy_if_different ${CMAKE_CURRENT_SOURCE_DIR}/test.png ${CMAKE_BINARY_DIR}/$<CONFIG>/test.png
     COMMAND ${CMAKE_COMMAND} -E copy_if_different ${CMAKE_CURRENT_SOURCE_DIR}/test.png ${CMAKE_BINARY_DIR}/${PROJECT_NAME}/test.png
 )
 

--- a/skshader_editor/CMakeLists.txt
+++ b/skshader_editor/CMakeLists.txt
@@ -96,6 +96,6 @@ add_dependencies(skshader_editor
     skshaderc)
 
 skshaderc_compile_headers(skshader_editor
-    ${CMAKE_BINARY_DIR}/shaders_editor
-    "-t xge"
+    ${CMAKE_BINARY_DIR}/shaders_editor/
+    "-e -t xge"
     imgui_shader.hlsl )

--- a/skshader_editor/CMakeLists.txt
+++ b/skshader_editor/CMakeLists.txt
@@ -76,11 +76,11 @@ add_executable(skshader_editor
     TextEditor.cpp)
 
 add_custom_command(TARGET skshader_editor POST_BUILD
-    COMMAND ${CMAKE_COMMAND} -E copy_if_different ${CMAKE_CURRENT_SOURCE_DIR}/CascadiaMono.ttf ${CMAKE_BINARY_DIR}/$<CONFIG>/CascadiaMono.ttf
-    COMMAND ${CMAKE_COMMAND} -E copy_if_different ${CMAKE_CURRENT_SOURCE_DIR}/CascadiaMono.ttf ${CMAKE_BINARY_DIR}/${PROJECT_NAME}/CascadiaMono.ttf
-    COMMAND ${CMAKE_COMMAND} -E copy_if_different ${CMAKE_CURRENT_SOURCE_DIR}/test.png ${CMAKE_BINARY_DIR}/$<CONFIG>/test.png
-    COMMAND ${CMAKE_COMMAND} -E copy_if_different ${CMAKE_CURRENT_SOURCE_DIR}/test.png ${CMAKE_BINARY_DIR}/${PROJECT_NAME}/test.png
+    COMMAND ${CMAKE_COMMAND} -E copy_if_different ${CMAKE_CURRENT_SOURCE_DIR}/CascadiaMono.ttf $<TARGET_FILE_DIR:${PROJECT_NAME}>/CascadiaMono.ttf
+    COMMAND ${CMAKE_COMMAND} -E copy_if_different ${CMAKE_CURRENT_SOURCE_DIR}/test.png $<TARGET_FILE_DIR:${PROJECT_NAME}>/test.png
 )
+
+set_property(TARGET skshader_editor PROPERTY VS_DEBUGGER_WORKING_DIRECTORY $<TARGET_FILE_DIR:${PROJECT_NAME}>)
 
 if (UNIX)
     set( GL_LIBRARIES

--- a/skshader_editor/CMakeLists.txt
+++ b/skshader_editor/CMakeLists.txt
@@ -73,7 +73,9 @@ add_executable(skshader_editor
 
 add_custom_command(TARGET skshader_editor POST_BUILD
     COMMAND ${CMAKE_COMMAND} -E copy_if_different ${CMAKE_CURRENT_SOURCE_DIR}/CascadiaMono.ttf ${CMAKE_BINARY_DIR}/${CMAKE_BUILD_TYPE}/CascadiaMono.ttf
+    COMMAND ${CMAKE_COMMAND} -E copy_if_different ${CMAKE_CURRENT_SOURCE_DIR}/CascadiaMono.ttf ${CMAKE_BINARY_DIR}/${PROJECT_NAME}/CascadiaMono.ttf
     COMMAND ${CMAKE_COMMAND} -E copy_if_different ${CMAKE_CURRENT_SOURCE_DIR}/test.png ${CMAKE_BINARY_DIR}/${CMAKE_BUILD_TYPE}/test.png
+    COMMAND ${CMAKE_COMMAND} -E copy_if_different ${CMAKE_CURRENT_SOURCE_DIR}/test.png ${CMAKE_BINARY_DIR}/${PROJECT_NAME}/test.png
 )
 
 if (UNIX)

--- a/skshader_editor/CMakeLists.txt
+++ b/skshader_editor/CMakeLists.txt
@@ -34,7 +34,7 @@ CPMAddPackage(
 )
 
 # For optimizing SPIR-V shaders, a baseline amount of
-# optimization is crucial for meta compatability with
+# optimization is crucial for meta compatibility with
 # HLSL compilers.
 CPMAddPackage(
     NAME SPIRV-Tools

--- a/skshader_editor/CMakeLists.txt
+++ b/skshader_editor/CMakeLists.txt
@@ -69,6 +69,10 @@ add_executable(skshader_editor
     imgui/imgui_widgets.cpp
     imgui/imgui.cpp
     ../skshaderc/sksc.cpp
+    ../skshaderc/sksc_glsl.cpp
+    ../skshaderc/sksc_hlsl.cpp
+    ../skshaderc/sksc_log.cpp
+    ../skshaderc/sksc_meta.cpp
     TextEditor.cpp)
 
 add_custom_command(TARGET skshader_editor POST_BUILD
@@ -88,7 +92,7 @@ endif()
 
 target_link_libraries(skshader_editor
     PRIVATE
-    spirv-cross-c
+    spirv-cross-hlsl
     SPIRV-Tools-opt
     glslang
     SPIRV

--- a/skshader_editor/imgui_shader.hlsl
+++ b/skshader_editor/imgui_shader.hlsl
@@ -1,5 +1,5 @@
 cbuffer vertexBuffer : register(b0) {
-    float4x4 ProjectionMatrix;
+	float4x4 ProjectionMatrix;
 };
 
 struct vsIn {
@@ -9,9 +9,9 @@ struct vsIn {
 	float4 col  : COLOR0;
 };
 struct psIn {
-    float4 pos : SV_POSITION;
-    float4 col : COLOR0;
-    float2 uv  : TEXCOORD0;
+	float4 pos : SV_POSITION;
+	float4 col : COLOR0;
+	float2 uv  : TEXCOORD0;
 };
 
 sampler   sampler0 : register(s0);
@@ -22,13 +22,13 @@ float3 srgb_to_linear(float3 srgb) {
 }
 
 psIn vs(vsIn input) {
-    psIn output;
-    output.pos = mul( ProjectionMatrix, float4(input.pos.xy, 0.f, 1.f));
-    output.col = float4(srgb_to_linear(input.col.rgb),1);
-    output.uv  = input.uv;
-    return output;
+	psIn output;
+	output.pos = mul( ProjectionMatrix, float4(input.pos.xy, 0.f, 1.f));
+	output.col = float4(srgb_to_linear(input.col.rgb),1);
+	output.uv  = input.uv;
+	return output;
 }
 
 float4 ps(psIn input) : SV_Target {
-    return input.col * texture0.Sample(sampler0, input.uv);
+	return input.col * texture0.Sample(sampler0, input.uv);
 }

--- a/skshader_editor/imgui_shader.hlsl
+++ b/skshader_editor/imgui_shader.hlsl
@@ -1,14 +1,14 @@
 cbuffer vertexBuffer : register(b0) {
     float4x4 ProjectionMatrix;
 };
+
 struct vsIn {
 	float4 pos  : SV_Position;
 	float3 norm : NORMAL0;
 	float2 uv   : TEXCOORD0;
 	float4 col  : COLOR0;
 };
-
-struct PS_INPUT {
+struct psIn {
     float4 pos : SV_POSITION;
     float4 col : COLOR0;
     float2 uv  : TEXCOORD0;
@@ -21,14 +21,14 @@ float3 srgb_to_linear(float3 srgb) {
 	return srgb * (srgb * (srgb * 0.305306011 + 0.682171111) + 0.012522878);
 }
 
-PS_INPUT vs(VS_INPUT input) {
-    PS_INPUT output;
+psIn vs(vsIn input) {
+    psIn output;
     output.pos = mul( ProjectionMatrix, float4(input.pos.xy, 0.f, 1.f));
     output.col = float4(srgb_to_linear(input.col.rgb),1);
     output.uv  = input.uv;
     return output;
 }
 
-float4 ps(PS_INPUT input) : SV_Target {
+float4 ps(psIn input) : SV_Target {
     return input.col * texture0.Sample(sampler0, input.uv);
 }

--- a/skshader_editor/window_preview.h
+++ b/skshader_editor/window_preview.h
@@ -80,7 +80,7 @@ void window_preview_render() {
 	app_shader_set_engine_val(engine_val_matrix_view_projection, &viewproj);
 
 	float clear[4] = { 0,0,0,0 };
-	skg_tex_target_bind(&surface);
+	skg_tex_target_bind(&surface, -1, 0);
 	skg_target_clear(true, clear);
 
 	skg_pipeline_t *pipeline = app_shader_get_pipeline();
@@ -91,7 +91,7 @@ void window_preview_render() {
 		skg_draw         (0, 0, preview_meshes[preview_mesh_active].faces, 1);
 	}
 
-	skg_tex_target_bind(nullptr);
+	skg_tex_target_bind(nullptr, -1, 0);
 }
 
 void window_preview() {

--- a/skshader_editor/window_preview.h
+++ b/skshader_editor/window_preview.h
@@ -126,10 +126,12 @@ void window_preview() {
 	ImVec2 min  = ImGui::GetWindowContentRegionMin();
 	ImVec2 max  = ImGui::GetWindowContentRegionMax();
 	ImVec2 size = {max.x-min.x, max.y-min.y};
-	window_preview_resize((int32_t)size.x, (int32_t)size.y);
-	window_preview_render();
 	ImGui::SetCursorPos(min);
-	ImGui::Image((ImTextureID)&surface, size);
+	if (ImGui::IsRectVisible(size)) {
+		window_preview_resize((int32_t)size.x, (int32_t)size.y);
+		window_preview_render();
+		ImGui::Image((ImTextureID)&surface, size);
+	}
 	
 	ImGui::End();
 	ImGui::PopStyleVar();

--- a/skshader_editor/window_preview.h
+++ b/skshader_editor/window_preview.h
@@ -102,34 +102,35 @@ void window_preview() {
 	}
 
 	ImGui::PushStyleVar(ImGuiStyleVar_WindowPadding, ImVec2{ 0,0 });
-	ImGui::Begin("Preview");
 
-	/*if (ImGui::BeginMenuBar()) {
-		if (ImGui::BeginMenu("Mesh")) {
-			ImGui::EndMenu();
+	// Return false when window is collapsed, so you can early out in your code.
+	// You always need to call ImGui::End() even if false is returned.
+	if (ImGui::Begin("Preview")) {
+		/*if (ImGui::BeginMenuBar()) {
+			if (ImGui::BeginMenu("Mesh")) {
+				ImGui::EndMenu();
+			}
+			ImGui::EndMenuBar();
+		}*/
+
+		camera_arc_dist -= ImGui::GetIO().MouseWheel * .2f;
+		if (ImGui::IsMouseDragging(ImGuiMouseButton_Left) && ImGui::IsWindowHovered()) {
+			ImVec2 delta = ImGui::GetMouseDragDelta();
+			ImGui::ResetMouseDragDelta();
+			camera_arc_x -= delta.x * 0.005f;
+			camera_arc_y += delta.y * 0.005f;
+			if (camera_arc_y < -3.14159f / 2.0f)
+				camera_arc_y = -3.14159f / 2.0f;
+			if (camera_arc_y > 3.14159f / 2.0f)
+				camera_arc_y = 3.14159f / 2.0f;
 		}
-		ImGui::EndMenuBar();
-	}*/
 
-	camera_arc_dist -= ImGui::GetIO().MouseWheel * .2f;
-	if (ImGui::IsMouseDragging(ImGuiMouseButton_Left) && ImGui::IsWindowHovered()) {
-		ImVec2 delta = ImGui::GetMouseDragDelta();
-		ImGui::ResetMouseDragDelta();
-		camera_arc_x -= delta.x * 0.005f;
-		camera_arc_y += delta.y * 0.005f;
-		if (camera_arc_y < -3.14159f/2.0f)
-			camera_arc_y = -3.14159f/2.0f;
-		if (camera_arc_y >  3.14159f/2.0f)
-			camera_arc_y =  3.14159f/2.0f;
-	}
-
-	ImVec2 min  = ImGui::GetWindowContentRegionMin();
-	ImVec2 max  = ImGui::GetWindowContentRegionMax();
-	ImVec2 size = {max.x-min.x, max.y-min.y};
-	ImGui::SetCursorPos(min);
-	if (ImGui::IsRectVisible(size)) {
+		ImVec2 min = ImGui::GetWindowContentRegionMin();
+		ImVec2 max = ImGui::GetWindowContentRegionMax();
+		ImVec2 size = { max.x - min.x, max.y - min.y };
 		window_preview_resize((int32_t)size.x, (int32_t)size.y);
 		window_preview_render();
+		ImGui::SetCursorPos(min);
 		ImGui::Image((ImTextureID)&surface, size);
 	}
 	

--- a/skshader_editor/window_preview.h
+++ b/skshader_editor/window_preview.h
@@ -35,8 +35,8 @@ skg_tex_t    cube_tex   = {};
 
 void window_preview_resize(int32_t width, int32_t height) {
 	if (width != surface.width || height != surface.height) {
-		skg_tex_destroy(&surface);
-		skg_tex_destroy(&zbuffer);
+		if (skg_tex_is_valid(&surface)) skg_tex_destroy(&surface);
+		if (skg_tex_is_valid(&zbuffer)) skg_tex_destroy(&zbuffer);
 		surface = skg_tex_create(skg_tex_type_rendertarget, skg_use_static, skg_tex_fmt_rgba32, skg_mip_none);
 		zbuffer = skg_tex_create(skg_tex_type_depth, skg_use_static, skg_tex_fmt_depth32, skg_mip_none);
 		skg_tex_set_contents(&surface, nullptr, width, height);

--- a/skshader_editor/window_preview.h
+++ b/skshader_editor/window_preview.h
@@ -128,10 +128,12 @@ void window_preview() {
 		ImVec2 min = ImGui::GetWindowContentRegionMin();
 		ImVec2 max = ImGui::GetWindowContentRegionMax();
 		ImVec2 size = { max.x - min.x, max.y - min.y };
-		window_preview_resize((int32_t)size.x, (int32_t)size.y);
-		window_preview_render();
 		ImGui::SetCursorPos(min);
-		ImGui::Image((ImTextureID)&surface, size);
+		if (ImGui::IsRectVisible(size)) {
+			window_preview_resize((int32_t)size.x, (int32_t)size.y);
+			window_preview_render();
+			ImGui::Image((ImTextureID)&surface, size);
+		}
 	}
 	
 	ImGui::End();


### PR DESCRIPTION
Fixes:
1. `LINK : fatal error LNK1104: cannot open file 'spirv-cross-c.lib'`
2. `fatal error LNK1120: 13 unresolved externals`
3. Crash when the preview window was minimized (tried to create a texture with 0 height)
4. Issue building in Visual Studio due to missing text and image files
5. Syntax and flags for `skshaderc_compile_headers`
6. Stale signature for `skg_tex_target_bind`
    1. ![{430F8401-8F4F-4D80-9746-B919E33DBFBD}](https://github.com/user-attachments/assets/4dc13d96-3e4d-45b9-bf3f-5338e4456dcd)
8. Stale struct name in imgui_shader.hlsl
    1. ![image](https://github.com/user-attachments/assets/b0c3c7f4-be32-4223-8ec2-5946012773b4)