### PR TITLE
Fix trailing slash logic

### DIFF
--- a/skshaderc/main.cpp
+++ b/skshaderc/main.cpp
@@ -314,7 +314,7 @@ void compile_file(const char *src_filename, compiler_settings_t *settings) {
 
 	const char *dest_folder    = settings->out_folder ? settings->out_folder : dir;
 	char        trailing_char  = dest_folder[strlen(dest_folder) - 1];
-	const char *trailing_slash = trailing_char == '/' ? "/" : (trailing_char == '\\' ? "\\" : "");
+	const char *trailing_slash = trailing_char == '/' || trailing_char == '\\' ? "" : "/";
 	const char *name_ext_mod   = settings->replace_ext ? name : name_ext;
 	bool        make_sks       = settings->force_sks || (
 		settings->output_header      == false && 


### PR DESCRIPTION
Looks like this logic was changed in https://github.com/StereoKit/sk_gpu/commit/8f7d690bc6fc2590d27544432c22e45b8cd93684#diff-f2b899c116f19326a264db0dc62c563e31aee4abd26f2f9f7bf0a7229017992aL283 and is now causing incorrect output paths.

The logic was flipped from "if there's a trailing slash, don't add one. otherwise, add one." to "if there's a trailing slash, add another one. otherwise, don't."

For example, I'm seeing `bin\intermediate\x64_Release\StereoKitC\shadersshader_builtin_blit.h` instead of `bin\intermediate\x64_Release\StereoKitC\shaders\shader_builtin_blit.h` when building SK.