### PR TITLE
feat: Make sk_gpu findable via cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.7)
+cmake_minimum_required(VERSION 3.12)
 
 project(sk_gpu VERSION 0.1
                DESCRIPTION "Single header cross-platform graphics api."
@@ -19,3 +19,23 @@ endif()
 if (SK_BUILD_EXAMPLES)
     add_subdirectory(examples/sk_gpu_flat)
 endif()
+
+include(CMakePackageConfigHelpers)
+
+write_basic_package_version_file(
+    "${CMAKE_CURRENT_BINARY_DIR}/sk_gpuConfigVersion.cmake"
+    VERSION ${PROJECT_VERSION}
+    COMPATIBILITY AnyNewerVersion
+)
+
+configure_package_config_file(
+    "${CMAKE_CURRENT_SOURCE_DIR}/cmake/sk_gpuConfig.cmake.in"
+    "${CMAKE_CURRENT_BINARY_DIR}/sk_gpuConfig.cmake"
+    INSTALL_DESTINATION lib/cmake/sk_gpu
+)
+
+install(FILES
+    "${CMAKE_CURRENT_BINARY_DIR}/sk_gpuConfig.cmake"
+    "${CMAKE_CURRENT_BINARY_DIR}/sk_gpuConfigVersion.cmake"
+    DESTINATION lib/cmake/sk_gpu
+)

--- a/cmake/sk_gpuConfig.cmake.in
+++ b/cmake/sk_gpuConfig.cmake.in
@@ -1,0 +1,11 @@
+@PACKAGE_INIT@
+
+set(SKSHADERC_EXE_PATH "@CMAKE_INSTALL_PREFIX@/bin/skshaderc_exe" CACHE FILEPATH "Path to skshaderc compiler")
+
+if(NOT EXISTS "${SKSHADERC_EXE_PATH}")
+    message(FATAL_ERROR "SKSHADERC_EXE_PATH is not set or the skshaderc binary does not exist at ${SKSHADERC_EXE_PATH}")
+endif()
+
+include("${CMAKE_CURRENT_LIST_DIR}/sk_gpuTargets.cmake")
+
+include("${CMAKE_CURRENT_LIST_DIR}/sk_gpuFunctions.cmake")

--- a/cmake/sk_gpuFunctions.cmake
+++ b/cmake/sk_gpuFunctions.cmake
@@ -1,0 +1,37 @@
+function(SKSHADERC_COMPILE_ASSETS TARGET COMMAND_STRING OUT_LIST)
+    message(STATUS "sk_gpu compiling shader assets with args '${SKSHADERC_EXE_PATH} ${COMMAND_STRING}'")
+    set(SKSHADERC_COMPILE_COMMANDS ${COMMAND_STRING})
+    separate_arguments(SKSHADERC_COMPILE_COMMANDS)
+
+    set(SHADER_LIST)
+    foreach(SHADER IN LISTS ARGN)
+        add_custom_command(
+            TARGET ${TARGET} PRE_BUILD
+            COMMAND ${SKSHADERC_EXE_PATH} ${SKSHADERC_COMPILE_COMMANDS} ${CMAKE_CURRENT_SOURCE_DIR}/${SHADER}
+            VERBATIM
+        )
+        list(APPEND SHADER_LIST ${SHADER})
+    endforeach(SHADER)
+
+    set(${OUT_LIST} ${SHADER_LIST} PARENT_SCOPE)
+endfunction()
+
+function(SKSHADERC_COMPILE_HEADERS ADD_TARGET OUTPUT_FOLDER COMMAND_STRING)
+    set(SKSHADERC_COMPILE_COMMANDS "-h -o ${OUTPUT_FOLDER} ${COMMAND_STRING}")
+    message(STATUS "sk_gpu compiling shader headers with args '${SKSHADERC_EXE_PATH} ${SKSHADERC_COMPILE_COMMANDS}'")
+    separate_arguments(SKSHADERC_COMPILE_COMMANDS)
+
+    set(SHADER_LIST)
+    foreach(SHADER IN LISTS ARGN)
+        get_filename_component(SHADER_NAME ${SHADER} NAME)
+        add_custom_command(
+            OUTPUT ${OUTPUT_FOLDER}/${SHADER_NAME}.h
+            COMMAND ${SKSHADERC_EXE_PATH} ${SKSHADERC_COMPILE_COMMANDS} ${CMAKE_CURRENT_SOURCE_DIR}/${SHADER}
+            VERBATIM
+        )
+        list(APPEND SHADER_LIST ${OUTPUT_FOLDER}/${SHADER_NAME}.h)
+    endforeach(SHADER)
+
+    target_include_directories(${ADD_TARGET} PRIVATE ${OUTPUT_FOLDER})
+    target_sources            (${ADD_TARGET} PRIVATE ${SHADER_LIST})
+endfunction()

--- a/skshader_editor/CMakeLists.txt
+++ b/skshader_editor/CMakeLists.txt
@@ -105,3 +105,13 @@ skshaderc_compile_headers(skshader_editor
     ${CMAKE_BINARY_DIR}/shaders_editor/
     "-e -t xge"
     imgui_shader.hlsl )
+
+install(TARGETS skshader_editor
+        RUNTIME DESTINATION bin)
+
+install(DIRECTORY ${CMAKE_BINARY_DIR}/shaders_editor/
+        DESTINATION share/skshader_editor/shaders
+        FILES_MATCHING PATTERN "*.h")
+
+install(FILES CascadiaMono.ttf test.png
+        DESTINATION share/skshader_editor)

--- a/skshader_editor/CMakeLists.txt
+++ b/skshader_editor/CMakeLists.txt
@@ -16,46 +16,60 @@ endif()
 include(../cmake/CPM.cmake)
 
 # For converting SPIR-V to flavors of GLSL
-CPMAddPackage(
-    NAME SPIRV-Cross
-    GITHUB_REPOSITORY KhronosGroup/SPIRV-Cross
-    GIT_TAG vulkan-sdk-1.3.275.0
-    OPTIONS 
-    "SPIRV_CROSS_CLI OFF" 
-    "SPIRV_CROSS_ENABLE_TESTS OFF" 
-    "SPIRV_CROSS_ENABLE_MSL OFF"
-)
+find_package(spirv_cross_core)
+find_package(spirv_cross_glsl)
+find_package(spirv_cross_hlsl)
+if(NOT spirv_cross_core_FOUND)
+    CPMAddPackage(
+        NAME SPIRV-Cross
+        GITHUB_REPOSITORY KhronosGroup/SPIRV-Cross
+        GIT_TAG vulkan-sdk-1.3.275.0
+        OPTIONS 
+        "SPIRV_CROSS_CLI OFF" 
+        "SPIRV_CROSS_ENABLE_TESTS OFF" 
+        "SPIRV_CROSS_ENABLE_MSL OFF"
+    )
+endif()
 
 # For SPIRV-Tools
-CPMAddPackage(
-    NAME SPIRV-Headers
-    GITHUB_REPOSITORY KhronosGroup/SPIRV-Headers
-    GIT_TAG vulkan-sdk-1.3.275.0 # This version should match up with the SPIRV-Tools version
-)
+find_package(SPIRV-Headers)
+if(NOT SPIRV-Headers_FOUND)
+    CPMAddPackage(
+        NAME SPIRV-Headers
+        GITHUB_REPOSITORY KhronosGroup/SPIRV-Headers
+        GIT_TAG vulkan-sdk-1.3.275.0 # This version should match up with the SPIRV-Tools version
+    )
+endif()
 
 # For optimizing SPIR-V shaders, a baseline amount of
 # optimization is crucial for meta compatibility with
-# HLSL compilers.
-CPMAddPackage(
-    NAME SPIRV-Tools
-    GITHUB_REPOSITORY KhronosGroup/SPIRV-Tools
-    GIT_TAG vulkan-sdk-1.3.275.0 # This version should match up with the SPIRV-Headers version
-    OPTIONS
-    "SPIRV_SKIP_TESTS ON"
-    "SPIRV_SKIP_EXECUTABLES ON"
-    "SPIRV_WERROR OFF"
-)
+# HLSL compilers.   
+find_package(SPIRV-Tools)
+if(NOT SPIRV-Tools_FOUND)
+    CPMAddPackage(
+        NAME SPIRV-Tools
+        GITHUB_REPOSITORY KhronosGroup/SPIRV-Tools
+        GIT_TAG vulkan-sdk-1.3.275.0 # This version should match up with the SPIRV-Headers version
+        OPTIONS
+        "SPIRV_SKIP_TESTS ON"
+        "SPIRV_SKIP_EXECUTABLES ON"
+        "SPIRV_WERROR OFF"
+    )
+endif()
 
 # This is used to convert HLSL to SPIR-V. DXC is an
 # alternative, but is far more difficult to compile,
 # and generates a much larger binary.
-CPMAddPackage(
-    NAME glslang
-    GITHUB_REPOSITORY KhronosGroup/glslang
-    GIT_TAG 14.1.0
-    OPTIONS 
-    "SKIP_GLSLANG_INSTALL ON"
-)
+find_package(glslang)
+if(NOT glslang_FOUND)
+    CPMAddPackage(
+        NAME glslang
+        GITHUB_REPOSITORY KhronosGroup/glslang
+        GIT_TAG 14.1.0
+        OPTIONS 
+        "SKIP_GLSLANG_INSTALL ON"
+    )
+endif()
 
 ## Target definition
 

--- a/skshader_editor/app_shader.cpp
+++ b/skshader_editor/app_shader.cpp
@@ -118,7 +118,7 @@ void app_shader_show_log() {
 	for (int32_t i = 0; i < sksc_log_count(); i++) {
 		sksc_log_item_t item = sksc_log_get(i);
 		if (item.level > 0)
-			ImGui::Text(item.text);
+			ImGui::Text("%s", item.text);
 	}
 	ImGui::End();
 }

--- a/skshaderc/CMakeLists.txt
+++ b/skshaderc/CMakeLists.txt
@@ -42,56 +42,70 @@ endif()
 include(../cmake/CPM.cmake)
 
 # For converting SPIR-V to flavors of GLSL
-CPMAddPackage(
-    NAME SPIRV-Cross
-    GITHUB_REPOSITORY KhronosGroup/SPIRV-Cross
-    GIT_TAG vulkan-sdk-1.3.296.0
-    OPTIONS 
-    "SPIRV_CROSS_CLI OFF" 
-    "SPIRV_CROSS_ENABLE_TESTS OFF"
-    "SPIRV_CROSS_ENABLE_MSL OFF"
-    "SPIRV_CROSS_ENABLE_CPP OFF"
-    "SPIRV_CROSS_ENABLE_REFLECT OFF"
-    "SPIRV_CROSS_ENABLE_C_API OFF"
-    "SPIRV_CROSS_ENABLE_UTIL OFF"
-)
+find_package(spirv_cross_core)
+find_package(spirv_cross_glsl)
+find_package(spirv_cross_hlsl)
+if(NOT spirv_cross_core_FOUND)
+    CPMAddPackage(
+        NAME SPIRV-Cross
+        GITHUB_REPOSITORY KhronosGroup/SPIRV-Cross
+        GIT_TAG vulkan-sdk-1.3.296.0
+        OPTIONS 
+        "SPIRV_CROSS_CLI OFF" 
+        "SPIRV_CROSS_ENABLE_TESTS OFF" 
+        "SPIRV_CROSS_ENABLE_MSL OFF"
+        "SPIRV_CROSS_ENABLE_CPP OFF"
+        "SPIRV_CROSS_ENABLE_REFLECT OFF"
+        "SPIRV_CROSS_ENABLE_C_API OFF"
+        "SPIRV_CROSS_ENABLE_UTIL OFF"
+    )
+endif()
 
 # For SPIRV-Tools
-CPMAddPackage(
-    NAME SPIRV-Headers
-    GITHUB_REPOSITORY KhronosGroup/SPIRV-Headers
-    GIT_TAG vulkan-sdk-1.3.296.0 # This version should match up with the SPIRV-Tools version
-)
+find_package(SPIRV-Headers)
+if(NOT SPIRV-Headers_FOUND)
+    CPMAddPackage(
+        NAME SPIRV-Headers
+        GITHUB_REPOSITORY KhronosGroup/SPIRV-Headers
+        GIT_TAG vulkan-sdk-1.3.296.0 # This version should match up with the SPIRV-Tools version
+    )
+endif()
 
 # For optimizing SPIR-V shaders, a baseline amount of
-# optimization is crucial for meta compatability with
-# HLSL compilers.
-CPMAddPackage(
-    NAME SPIRV-Tools
-    GITHUB_REPOSITORY KhronosGroup/SPIRV-Tools
-    GIT_TAG vulkan-sdk-1.3.296.0 # This version should match up with the SPIRV-Headers version
-    OPTIONS
-    "SPIRV_SKIP_TESTS ON"
-    "SPIRV_SKIP_EXECUTABLES ON"
-    "SPIRV_WERROR OFF"
-)
+# optimization is crucial for meta compatibility with
+# HLSL compilers.   
+find_package(SPIRV-Tools)
+if(NOT SPIRV-Tools_FOUND)
+    CPMAddPackage(
+        NAME SPIRV-Tools
+        GITHUB_REPOSITORY KhronosGroup/SPIRV-Tools
+        GIT_TAG vulkan-sdk-1.3.296.0 # This version should match up with the SPIRV-Headers version
+        OPTIONS
+        "SPIRV_SKIP_TESTS ON"
+        "SPIRV_SKIP_EXECUTABLES ON"
+        "SPIRV_WERROR OFF"
+    )
+endif()
 
 # This is used to convert HLSL to SPIR-V. DXC is an
 # alternative, but is far more difficult to compile,
 # and generates a much larger binary.
-CPMAddPackage(
-    NAME glslang
-    GITHUB_REPOSITORY KhronosGroup/glslang
-    GIT_TAG vulkan-sdk-1.3.296.0
-    OPTIONS 
-    "GLSLANG_ENABLE_INSTALL OFF"
-    "GLSLANG_TESTS OFF"
-    "ENABLE_GLSLANG_BINARIES OFF"
-    "ENABLE_SPVREMAPPER OFF"
-    "ENABLE_GLSLANG_JS OFF"
-    "ENABLE_HLSL ON"
-    "ENABLE_RTTI OFF"
-)
+find_package(glslang)
+if(NOT glslang_FOUND)
+    CPMAddPackage(
+        NAME glslang
+        GITHUB_REPOSITORY KhronosGroup/glslang
+        GIT_TAG vulkan-sdk-1.3.296.0
+        OPTIONS 
+        "GLSLANG_ENABLE_INSTALL OFF"
+        "GLSLANG_TESTS OFF"
+        "ENABLE_GLSLANG_BINARIES OFF"
+        "ENABLE_SPVREMAPPER OFF"
+        "ENABLE_GLSLANG_JS OFF"
+        "ENABLE_HLSL ON"
+        "ENABLE_RTTI OFF"
+    )
+endif()
 
 if (UNIX)
     set(LINUX_LIBS)

--- a/skshaderc/CMakeLists.txt
+++ b/skshaderc/CMakeLists.txt
@@ -134,41 +134,8 @@ endif()
 
 set(SKSHADERC_EXE_PATH $<TARGET_FILE:skshaderc> PARENT_SCOPE)
 
+install(TARGETS skshaderc
+        RUNTIME DESTINATION bin)
+
 # functions for compiling shaders easily
-function(SKSHADERC_COMPILE_ASSETS TARGET COMMAND_STRING OUT_LIST)
-    message(STATUS "sk_gpu compiling shader assets with args '${SKSHADERC_EXE_PATH} ${COMMAND_STRING}'")
-    set(SKSHADERC_COMPILE_COMMANDS ${COMMAND_STRING})
-    separate_arguments(SKSHADERC_COMPILE_COMMANDS)
-
-    set(SHADER_LIST)
-    foreach(SHADER IN LISTS ARGN)
-        add_custom_command(
-            TARGET ${TARGET} PRE_BUILD
-            COMMAND ${SKSHADERC_EXE_PATH} ${SKSHADERC_COMPILE_COMMANDS} ${CMAKE_CURRENT_SOURCE_DIR}/${SHADER}
-            VERBATIM
-        )
-        list(APPEND SHADER_LIST ${SHADER})
-    endforeach(SHADER)
-
-    set(${OUT_LIST} ${SHADER_LIST} PARENT_SCOPE)
-endfunction()
-
-function(SKSHADERC_COMPILE_HEADERS ADD_TARGET OUTPUT_FOLDER COMMAND_STRING)
-    set(SKSHADERC_COMPILE_COMMANDS "-h -o ${OUTPUT_FOLDER} ${COMMAND_STRING}")
-    message(STATUS "sk_gpu compiling shader headers with args '${SKSHADERC_EXE_PATH} ${SKSHADERC_COMPILE_COMMANDS}'")
-    separate_arguments(SKSHADERC_COMPILE_COMMANDS)
-
-    set(SHADER_LIST)
-    foreach(SHADER IN LISTS ARGN)
-        get_filename_component(SHADER_NAME ${SHADER} NAME)
-        add_custom_command(
-            OUTPUT ${OUTPUT_FOLDER}/${SHADER_NAME}.h
-            COMMAND ${SKSHADERC_EXE_PATH} ${SKSHADERC_COMPILE_COMMANDS} ${CMAKE_CURRENT_SOURCE_DIR}/${SHADER}
-            VERBATIM
-        )
-        list(APPEND SHADER_LIST ${OUTPUT_FOLDER}/${SHADER_NAME}.h)
-    endforeach(SHADER)
-
-    target_include_directories(${ADD_TARGET} PRIVATE ${OUTPUT_FOLDER})
-    target_sources            (${ADD_TARGET} PRIVATE ${SHADER_LIST})
-endfunction()
+include("../cmake/sk_gpuFunctions.cmake")

--- a/skshaderc/sksc_hlsl.cpp
+++ b/skshaderc/sksc_hlsl.cpp
@@ -3,8 +3,8 @@
 #define ENABLE_HLSL
 
 #include <glslang/Public/ShaderLang.h>
+#include <glslang/SPIRV/GlslangToSpv.h>
 #include "StandAlone/DirStackFileIncluder.h"
-#include "SPIRV/GlslangToSpv.h"
 
 #include <spirv-tools/optimizer.hpp>
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -23,6 +23,29 @@ add_custom_command(
 )
 
 add_custom_target(sk_gpu_header ALL
-    DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/../sk_gpu.h")
+    DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/../sk_gpu.h"
+)
 
-install(FILES ${CMAKE_CURRENT_SOURCE_DIR}../sk_gpu.h DESTINATION include)
+add_library(sk_gpu INTERFACE)
+
+add_dependencies(sk_gpu sk_gpu_header)
+
+target_include_directories(sk_gpu INTERFACE
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/..>
+    $<INSTALL_INTERFACE:include>
+)
+
+install(FILES "${CMAKE_CURRENT_SOURCE_DIR}/../sk_gpu.h"
+        DESTINATION include)
+
+install(TARGETS sk_gpu
+        EXPORT sk_gpuTargets
+        INCLUDES DESTINATION include)
+
+install(EXPORT sk_gpuTargets
+        FILE sk_gpuTargets.cmake
+        NAMESPACE sk_gpu::
+        DESTINATION lib/cmake/sk_gpu)
+
+install(FILES "${CMAKE_CURRENT_SOURCE_DIR}/../cmake/sk_gpuFunctions.cmake"
+    DESTINATION lib/cmake/sk_gpu)


### PR DESCRIPTION
Makes it so that sk_gpu correctly installs its own targets, adds a cmake configuration target, and makes use of system packages where possible to avoid unnecessary network requests during build.